### PR TITLE
feat: added a bridge between gz and ros2 topics, closes #27

### DIFF
--- a/rl_obstacle_avoidance/config/bridge.yaml
+++ b/rl_obstacle_avoidance/config/bridge.yaml
@@ -1,0 +1,11 @@
+- ros_topic_name: "/lidar/x3"
+  gz_topic_name: "/lidar/x3"
+  ros_type_name: "sensor_msgs/msg/LaserScan"
+  gz_type_name: "ignition.msgs.LaserScan"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/X3/gazebo/command/motor_speed"
+  gz_topic_name: "/X3/gazebo/command/motor_speed"
+  ros_type_name: "geometry_msgs/msg/Twist"
+  gz_type_name: "ignition.msgs.Twist"
+  direction: ROS_TO_GZ

--- a/rl_obstacle_avoidance/launch/gz_sim.launch.py
+++ b/rl_obstacle_avoidance/launch/gz_sim.launch.py
@@ -4,6 +4,7 @@ from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 from launch.substitutions import PathJoinSubstitution
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from ros_gz_bridge.actions import RosGzBridge
 
 
 def generate_launch_description():
@@ -11,14 +12,17 @@ def generate_launch_description():
     pkg_rl_drone = get_package_share_directory('rl_obstacle_avoidance')
 
     world_file = PathJoinSubstitution([pkg_rl_drone, 'worlds', 'drone_world.sdf'])
-    # model_file = PathJoinSubstitution([pkg_rl_drone, 'models', 'parrot_bebop_2', 'model.sdf'])
+    bridge_config = PathJoinSubstitution([pkg_rl_drone, 'config', 'bridge.yaml'])
+
+    # Declare bridge config as a launch argument
+    declare_bridge_config = DeclareLaunchArgument(
+        'config_file',
+        default_value=bridge_config,
+        description='YAML file for ROS-Gazebo bridge'
+    )
 
     return LaunchDescription([
-        DeclareLaunchArgument(
-            'world',
-            default_value=world_file,
-            description='Path to the Gazebo world file'
-        ),
+        declare_bridge_config,  # Add bridge argument
 
         # Launch Gazebo with the world file
         IncludeLaunchDescription(
@@ -28,5 +32,9 @@ def generate_launch_description():
             launch_arguments={'gz_args': world_file}.items(),
         ),
 
-       
+        # Start ROS-Gazebo Bridge
+        RosGzBridge(
+            bridge_name="ros_gz_bridge",
+            config_file=bridge_config,
+        ),
     ])

--- a/rl_obstacle_avoidance/setup.py
+++ b/rl_obstacle_avoidance/setup.py
@@ -14,6 +14,7 @@ setup(
         ('share/' + package_name, ['package.xml']),
         (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
         (os.path.join('share', package_name, 'worlds'), glob('worlds/*.sdf')),
+        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),
         
         # X3 UAV
         (os.path.join('share', package_name, 'models/x3'), 


### PR DESCRIPTION
This pull request includes several changes to the `rl_obstacle_avoidance` package to integrate ROS-Gazebo bridge functionality. The most important changes involve adding new configuration files, updating launch files to include the bridge, and modifying the setup script to ensure proper installation of the new configuration files.

Changes to configuration and launch files:

* [`rl_obstacle_avoidance/config/bridge.yaml`](diffhunk://#diff-d99b2efc13473eecf0b16de0db75e34992bf58f6494cb20fafe87c60249b5430R1-R11): Added new configuration for ROS-Gazebo bridge, specifying topics and message types for communication between ROS and Gazebo.
* [`rl_obstacle_avoidance/launch/gz_sim.launch.py`](diffhunk://#diff-df0525de2099f64f5ffe48a119409fdc4697182a9f695785de855fe84aa1f496R7-R25): Updated the launch file to include the ROS-Gazebo bridge configuration and start the bridge during the launch process. [[1]](diffhunk://#diff-df0525de2099f64f5ffe48a119409fdc4697182a9f695785de855fe84aa1f496R7-R25) [[2]](diffhunk://#diff-df0525de2099f64f5ffe48a119409fdc4697182a9f695785de855fe84aa1f496L31-R39)

Changes to setup script:

* [`rl_obstacle_avoidance/setup.py`](diffhunk://#diff-d16cb631b6db1b2dfdaf4c8e305a9f1f6783e9be9ef653b0e6e460740254ab74R17): Modified the setup script to include the new configuration directory and its YAML files in the installation process.