### PR TITLE
fix: fixed ros_type for actuators, closes #41

### DIFF
--- a/rl_obstacle_avoidance/config/bridge.yaml
+++ b/rl_obstacle_avoidance/config/bridge.yaml
@@ -6,7 +6,7 @@
 
 - ros_topic_name: "/X3/gazebo/command/motor_speed"
   gz_topic_name: "/X3/gazebo/command/motor_speed"
-  ros_type_name: "geometry_msgs/msg/Twist"
+  ros_type_name: "actuator_msgs/msg/Actuators"
   gz_type_name: "gz.msgs.Actuators"
   direction: ROS_TO_GZ
 


### PR DESCRIPTION
To test the actuators, run the following command

```bash
ros2 topic pub /X3/gazebo/command/motor_speed actuator_msgs/msg/Actuators "{velocity: [100.0, 100.0, 100.0, 100.0]}"
```